### PR TITLE
Support for motion detection

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -132,6 +132,11 @@ class HikCamera(object):
         """Return Event states dictionary"""
         return self.event_states
 
+    @property
+    def current_motion_detection_state(self):
+        """Return current state of motion detection property"""
+        return self.motion_detection
+
     def get_motion_detection(self):
         url = '%s/MotionDetection/1' % self.root_url
         try:
@@ -178,7 +183,9 @@ class HikCamera(object):
 
     def _set_motion_detection(self, enable):
         url = '%s/MotionDetection/1' % self.root_url
-        self.get_motion_detection()
+        current_state = self.get_motion_detection()
+        if enable == current_state
+            return
 
         enabled = self._motion_detection_xml.find(self.element_query('enabled'))
         if enabled is None:
@@ -257,7 +264,7 @@ class HikCamera(object):
         else:
             _LOGGING.debug('No Events available in dictionary.')
 
-        self.motion_detection = self.get_motion_detection()
+        self.get_motion_detection()
 
     def get_event_triggers(self):
         """

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -37,7 +37,12 @@ from pyhik.constants import (
     DEFAULT_PORT, DEFAULT_HEADERS, XML_NAMESPACE, SENSOR_MAP,
     CAM_DEVICE, NVR_DEVICE, __version__)
 
+logging.basicConfig(format=(
+    '%(asctime)s,%(msecs)d %(levelname)-8s '
+    '[%(filename)s:%(lineno)d] %(message)s'
+))
 _LOGGING = logging.getLogger(__name__)
+
 
 # Hide nuisance requests logging
 logging.getLogger('urllib3').setLevel(logging.ERROR)
@@ -45,11 +50,7 @@ logging.getLogger('urllib3').setLevel(logging.ERROR)
 
 """
 Things still to do:
- - Support status of motion detection and turning on/off
  - Support status of day/night and switching
-
-Motion detection URL:
-http://X.X.X.X/ISAPI/System/Video/inputs/channels/1/motionDetection
 
 IR switch URL:
 http://X.X.X.X/ISAPI/Image/channels/1/ircutFilter
@@ -89,6 +90,7 @@ class HikCamera(object):
         self.cam_id = 0
         self.name = ''
         self.device_type = None
+        self.motion_detection_xml = None
 
         self.root_url = '{}:{}'.format(host, port)
 
@@ -131,6 +133,72 @@ class HikCamera(object):
     def current_event_states(self):
         """Return Event states dictionary"""
         return self.event_states
+
+    def get_motion_detection(self):
+        url = '%s/MotionDetection/1' % self.root_url
+        try:
+            response = self.hik_request.get(url)
+        except requests.exceptions.RequestException as err:
+            _LOGGING.error('Unable to fetch MotionDetection, error: %s', err)
+            return None
+
+        if response.status_code == requests.codes.unauthorized:
+            _LOGGING.error('Authentication failed')
+            return None
+
+        if response.status_code != requests.codes.ok:
+            # If we didn't receive 200, abort
+            _LOGGING.debug('Unable to fetch motion detection.')
+            return None
+
+        try:
+            tree = ET.fromstring(response.text)
+            nmsp = tree.tag.split('}')[0].strip('{')
+            self.namespace = nmsp if nmsp.startswith('http') else XML_NAMESPACE
+            ET.register_namespace("", self.namespace)
+            enabled = tree.find(self.element_query('enabled'))
+
+            if enabled is not None:
+                self.motion_detection_xml = tree
+            return {'true': True, 'false': False}[enabled.text]
+
+        except AttributeError as err:
+            _LOGGING.error('Entire response: %s', response.text)
+            _LOGGING.error('There was a problem: %s', err)
+            return None
+
+    def enable_motion_detection(self):
+        self._set_motion_detection(True)
+
+    def disable_motion_detection(self):
+        self._set_motion_detection(False)
+
+    def _set_motion_detection(self, enable):
+        url = '%s/MotionDetection/1' % self.root_url
+        self.get_motion_detection()
+
+        enabled = self.motion_detection_xml.find(self.element_query('enabled'))
+        if enabled is None:
+            _LOGGING.error("Couldn't find 'enabled' in the xml")
+            _LOGGING.error('XML: %s', ET.tostring(self.motion_detection_xml))
+            return
+
+        enabled.text = 'true' if enable else 'false'
+        xml = ET.tostring(self.motion_detection_xml)
+
+        try:
+            response = self.hik_request.put(url, data=xml)
+        except requests.exceptions.RequestException as err:
+            _LOGGING.error('Unable to set MotionDetection, error: %s', err)
+            return
+
+        if response.status_code == requests.codes.unauthorized:
+            _LOGGING.error('Authentication failed')
+            return
+
+        if response.status_code != requests.codes.ok:
+            # If we didn't receive 200, abort
+            _LOGGING.error('Unable to set motion detection: %s', response.text)
 
     def add_update_callback(self, callback, sensor):
         """Register as callback for when a matching device sensor changes."""

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -37,10 +37,7 @@ from pyhik.constants import (
     DEFAULT_PORT, DEFAULT_HEADERS, XML_NAMESPACE, SENSOR_MAP,
     CAM_DEVICE, NVR_DEVICE, __version__)
 
-logging.basicConfig(format=(
-    '%(asctime)s,%(msecs)d %(levelname)-8s '
-    '[%(filename)s:%(lineno)d] %(message)s'
-))
+
 _LOGGING = logging.getLogger(__name__)
 
 

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -138,7 +138,9 @@ class HikCamera(object):
         return self.motion_detection
 
     def get_motion_detection(self):
-        url = '%s/MotionDetection/1' % self.root_url
+        url = ('%s/ISAPI/System/Video/inputs/'
+               'channels/1/motionDetection') % self.root_url
+
         try:
             response = self.hik_request.get(url)
         except requests.exceptions.RequestException as err:
@@ -159,8 +161,6 @@ class HikCamera(object):
 
         try:
             tree = ET.fromstring(response.text)
-            nmsp = tree.tag.split('}')[0].strip('{')
-            self.namespace = nmsp if nmsp.startswith('http') else XML_NAMESPACE
             ET.register_namespace("", self.namespace)
             enabled = tree.find(self.element_query('enabled'))
 
@@ -182,10 +182,8 @@ class HikCamera(object):
         self._set_motion_detection(False)
 
     def _set_motion_detection(self, enable):
-        url = '%s/MotionDetection/1' % self.root_url
-        current_state = self.get_motion_detection()
-        if enable == current_state
-            return
+        url = ('%s/ISAPI/System/Video/inputs/'
+               'channels/1/motionDetection') % self.root_url
 
         enabled = self._motion_detection_xml.find(self.element_query('enabled'))
         if enabled is None:
@@ -209,6 +207,8 @@ class HikCamera(object):
         if response.status_code != requests.codes.ok:
             # If we didn't receive 200, abort
             _LOGGING.error('Unable to set motion detection: %s', response.text)
+
+        self.motion_detection = enable
 
     def add_update_callback(self, callback, sensor):
         """Register as callback for when a matching device sensor changes."""

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import logging
+import requests
+import unittest
+
+from unittest.mock import MagicMock, patch, PropertyMock
+from pyhik.hikvision import HikCamera
+
+XML = """<MotionDetection xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
+    <enabled>{}</enabled>
+    <enableHighlight>true</enableHighlight>
+    <samplingInterval>2</samplingInterval>
+    <startTriggerTime>500</startTriggerTime>
+    <endTriggerTime>500</endTriggerTime>
+    <regionType>grid</regionType>
+    <Grid>
+        <rowGranularity>18</rowGranularity>
+        <columnGranularity>22</columnGranularity>
+    </Grid>
+    <MotionDetectionLayout version="2.0">
+        <sensitivityLevel>20</sensitivityLevel>
+        <layout>
+            <gridMap>000000000000000000000000000000000c007e0c007ffffc</gridMap>
+        </layout>
+    </MotionDetectionLayout>
+</MotionDetection>"""
+
+
+@patch("pyhik.hikvision.requests.Session")
+class HikvisionTestCase(unittest.TestCase):
+    @staticmethod
+    def set_motion_detection_state(get, value):
+        get.reset_mock()
+        mock = get.return_value
+        mock.reset_mock()
+        type(mock).ok = PropertyMock(return_value=True)
+        type(mock).status_code = PropertyMock(return_value=requests.codes.ok)
+        type(mock).text = PropertyMock(
+            return_value=XML.format("true" if value else "false")
+        )
+        return get
+
+    @patch("pyhik.hikvision.HikCamera.get_device_info")
+    @patch("pyhik.hikvision.HikCamera.get_event_triggers")
+    def test_motion_detection(self, *args):
+        session = args[-1].return_value
+        get = session.get
+        url = "localhost:80/ISAPI/System/Video/inputs/channels/1/motionDetection"
+
+        # Motion detection disabled
+        self.set_motion_detection_state(get, False)
+        device = HikCamera(host="localhost")
+        get.assert_called_once_with(url)
+        self.assertIsNotNone(device)
+        self.assertFalse(device.current_motion_detection_state)
+
+        # Motion detection enabled
+        self.set_motion_detection_state(get, True)
+        device = HikCamera(host="localhost")
+        self.assertIsNotNone(device)
+        self.assertTrue(device.current_motion_detection_state)
+
+        # Enable calls put with the expected data
+        self.set_motion_detection_state(get, True)
+        session.put.return_value = MagicMock(status_code=requests.codes.ok, ok=True)
+        device.enable_motion_detection()
+        session.put.assert_called_once_with(url, data=XML.format("true").encode())
+
+        # Disable
+        def change_get_response(url, data):
+            self.set_motion_detection_state(get, False)
+            return MagicMock(ok=True, status_code=requests.codes.ok)
+
+        self.set_motion_detection_state(get, True)
+        session.put = MagicMock(side_effect=change_get_response)
+        device = HikCamera(host="localhost")
+        self.assertTrue(device.current_motion_detection_state)
+        device.disable_motion_detection()
+        self.assertFalse(device.current_motion_detection_state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds 3 new methods to the public API:
 - get_motion_detection: returns a boolean telling if motion detection is enabled or disabled
 - enable_motion_detection
 - disable_motion_detection

In addition to that, changes a bit the logging format. The main reason for that change was to add the line number to quickly identify where things were being logged.

Based on the feedback on this I'm preparing another pull request to support enabling/disabling/getting the PIR alarm.