### PR TITLE
Add defocus, as a type of tamper detection supported by some Hik cameras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ target/
 bin/
 local/
 share/
+
+# IDE
+.vscode

--- a/pyhik/constants.py
+++ b/pyhik/constants.py
@@ -31,6 +31,7 @@ SENSOR_MAP = {
     'videoloss': 'Video Loss',
     'tamperdetection': 'Tamper Detection',
     'shelteralarm': 'Tamper Detection',
+    'defocus':'Tamper Detection',
     'diskfull': 'Disk Full',
     'diskerror': 'Disk Error',
     'nicbroken': 'Net Interface Broken',

--- a/pyhik/watchdog.py
+++ b/pyhik/watchdog.py
@@ -16,6 +16,7 @@ class Watchdog(object):
         """ Initialize watchdog variables. """
         self.time = timeout
         self.handler = handler
+        self._timer = None
         return
 
     def start(self):
@@ -33,4 +34,5 @@ class Watchdog(object):
 
     def stop(self):
         """ Stops the watchdog timer. """
-        self._timer.cancel()
+        if self._timer is not None:
+            self._timer.cancel()


### PR DESCRIPTION
My Hikvision ANPR camera frequently generates defocus events, and these cause a large trail of errors in HomeAssistant with pyhik integrated.

This PR just adds defocus as an alternate key for tamper detection, which has fixed the problem locally for me.