### PR TITLE
Fix unit tests and retrieve namespace from XML response

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -168,10 +168,6 @@ class HikCamera(object):
 
         try:
             tree = ET.fromstring(response.text)
-            nmsp = tree.tag.split('}')[0].strip('{')
-            self.namespace = nmsp if nmsp.startswith('http') else XML_NAMESPACE
-            _LOGGING.debug('Using Namespace: %s', self.namespace)
-
             ET.register_namespace("", self.namespace)
             enabled = tree.find(self.element_query('enabled'))
 

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -168,6 +168,10 @@ class HikCamera(object):
 
         try:
             tree = ET.fromstring(response.text)
+            nmsp = tree.tag.split('}')[0].strip('{')
+            self.namespace = nmsp if nmsp.startswith('http') else XML_NAMESPACE
+            _LOGGING.debug('Using Namespace: %s', self.namespace)
+
             ET.register_namespace("", self.namespace)
             enabled = tree.find(self.element_query('enabled'))
 

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -6,6 +6,7 @@ import unittest
 
 from unittest.mock import MagicMock, patch, PropertyMock
 from pyhik.hikvision import HikCamera
+from pyhik.constants import (CONNECT_TIMEOUT)
 
 XML = """<MotionDetection xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
     <enabled>{}</enabled>
@@ -44,6 +45,7 @@ class HikvisionTestCase(unittest.TestCase):
     @patch("pyhik.hikvision.HikCamera.get_device_info")
     @patch("pyhik.hikvision.HikCamera.get_event_triggers")
     def test_motion_detection(self, *args):
+
         session = args[-1].return_value
         get = session.get
         url = "localhost:80/ISAPI/System/Video/inputs/channels/1/motionDetection"
@@ -51,7 +53,7 @@ class HikvisionTestCase(unittest.TestCase):
         # Motion detection disabled
         self.set_motion_detection_state(get, False)
         device = HikCamera(host="localhost")
-        get.assert_called_once_with(url)
+        get.assert_called_once_with(url, timeout=CONNECT_TIMEOUT)
         self.assertIsNotNone(device)
         self.assertFalse(device.current_motion_detection_state)
 
@@ -65,10 +67,10 @@ class HikvisionTestCase(unittest.TestCase):
         self.set_motion_detection_state(get, True)
         session.put.return_value = MagicMock(status_code=requests.codes.ok, ok=True)
         device.enable_motion_detection()
-        session.put.assert_called_once_with(url, data=XML.format("true").encode())
+        session.put.assert_called_once_with(url, data=XML.format("true").encode(), timeout=CONNECT_TIMEOUT)
 
         # Disable
-        def change_get_response(url, data):
+        def change_get_response(url, data,timeout):
             self.set_motion_detection_state(get, False)
             return MagicMock(ok=True, status_code=requests.codes.ok)
 


### PR DESCRIPTION
Hi,

I updated my Hikvision NVR firmware and now the XML response namespace is [different](https://pastebin.com/BAQhi0B0) http://www.isapi.org/ver20/XMLSchema instead of http://www.hikvision.com/ver20/XMLSchema

My changes fix the unit tests and retrieve the XML namespace from the response.