### PR TITLE
Add verify_ssl to allow self-signed certificate

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -62,7 +62,7 @@ class HikCamera(object):
     """Creates a new Hikvision api device."""
 
     def __init__(self, host=None, port=DEFAULT_PORT,
-                 usr=None, pwd=None):
+                 usr=None, pwd=None, verify_ssl=True):
         """Initialize device."""
 
         _LOGGING.debug("pyHik %s initializing new hikvision device at: %s",
@@ -98,6 +98,9 @@ class HikCamera(object):
         # Default to basic authentication. It will change to digest inside
         # get_device_info if basic fails
         self.hik_request = requests.Session()
+
+        self.hik_request.verify = verify_ssl
+
         self.hik_request.auth = (usr, pwd)
         self.hik_request.headers.update(DEFAULT_HEADERS)
 


### PR DESCRIPTION
Adding the foundation to allow self-signed certificates to fix issue https://github.com/mezz64/pyHik/issues/60. I have the changes for HomeAssistant Core on standby [here](https://github.com/Maelstrom96/core/tree/hikvision-verify-ssl).