### PR TITLE
Fix last line of stream being stuck in buffer

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -492,6 +492,8 @@ class HikCamera(object):
         start_event = False
         parse_string = ""
         fail_count = 0
+        line = ""
+        buffer = b""
 
         url = '%s/ISAPI/Event/notification/alertStream' % self.root_url
 
@@ -514,8 +516,12 @@ class HikCamera(object):
                     fail_count = 0
                     self.watchdog.start()
 
-                for line in stream.iter_lines():
+                for chunk in stream.iter_content(chunk_size=1):
                     # _LOGGING.debug('Processing line from %s', self.name)
+                    buffer += chunk
+                    if chunk == b"\n":
+                        line = buffer
+                        buffer = b""
                     # filter out keep-alive new lines
                     if line:
                         str_line = line.decode("utf-8", "ignore")
@@ -539,6 +545,7 @@ class HikCamera(object):
                         else:
                             if start_event:
                                 parse_string += str_line
+                        line = ""
 
                     if kill_event.is_set():
                         # We were asked to stop the thread so lets do so.


### PR DESCRIPTION
requests.Response.iter_lines has a known issue where it will not return a line if the bytes in that line is less than the minimum size and it's the last line.
https://github.com/psf/requests/issues/3577

In my case it caused events to only be picked up when the next event came in from the DVR. So the motion event would only register when the next videoloss event came in or some other event.

Basically means the latest event is just never picked up. The second latest event according to the DVR will alway be the last one interpreted by the library.

In real life this caused my motion events to notify my home assistant with considerable lag. Up to 10 seconds.