### PR TITLE
Use urllib.parse for URL construction instead of string formatting

### DIFF
--- a/pyhik/constants.py
+++ b/pyhik/constants.py
@@ -8,7 +8,7 @@ Licensed under the MIT license.
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 4
-SUB_MINOR_VERSION = 2
+SUB_MINOR_VERSION = 3
 __version__ = '{}.{}.{}'.format(
     MAJOR_VERSION, MINOR_VERSION, SUB_MINOR_VERSION)
 

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -16,7 +16,7 @@ import datetime
 from dataclasses import dataclass
 import logging
 import uuid
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, urlunparse
 
 try:
     import xml.etree.cElementTree as ET
@@ -109,7 +109,12 @@ class HikCamera(object):
             _LOGGING.error('Host not specified! Cannot continue.')
             return
 
-        self.host = host
+        # Parse the host to extract clean hostname and determine scheme/port
+        parsed = urlparse(host if '://' in str(host) else f'http://{host}')
+        self.host = parsed.hostname or host
+        effective_port = parsed.port or port
+        scheme = parsed.scheme or 'http'
+
         self.usr = usr
         self.pwd = pwd
         self.cam_id = 0
@@ -118,7 +123,9 @@ class HikCamera(object):
         self.motion_detection = None
         self._motion_detection_xml = None
 
-        self.root_url = '{}:{}'.format(host, port)
+        self.root_url = urlunparse((
+            scheme, f'{self.host}:{effective_port}', '', '', '', ''
+        ))
 
         self.namespace = {
             CONTEXT_INFO: None,
@@ -321,17 +328,16 @@ class HikCamera(object):
         else:
             stream_channel = stream_type
 
-        # Extract host without port or protocol for RTSP URL
-        host = self.host
-        if '://' in host:
-            host = host.split('://')[1]
-
         # URL encode credentials for safety
         encoded_user = quote(self.usr, safe='')
         encoded_pwd = quote(self.pwd, safe='')
 
-        return 'rtsp://%s:%s@%s:%d/Streaming/Channels/%d' % (
-            encoded_user, encoded_pwd, host, DEFAULT_RTSP_PORT, stream_channel)
+        return urlunparse((
+            'rtsp',
+            f'{encoded_user}:{encoded_pwd}@{self.host}:{DEFAULT_RTSP_PORT}',
+            f'/Streaming/Channels/{stream_channel}',
+            '', '', ''
+        ))
 
     def get_channels(self):
         """
@@ -1135,7 +1141,10 @@ def get_video_channels(host, port, username, password, ssl=False):
         List of VideoChannel objects.
     """
     protocol = "https" if ssl else "http"
-    root_url = "{}://{}:{}".format(protocol, host, port)
+    parsed = urlparse(host if '://' in str(host) else f'{protocol}://{host}')
+    clean_host = parsed.hostname or host
+    effective_port = parsed.port or port
+    root_url = urlunparse((protocol, f'{clean_host}:{effective_port}', '', '', '', ''))
     channels = []
 
     session = requests.Session()

--- a/pyhik/isapi.py
+++ b/pyhik/isapi.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 import logging
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote, urlparse, urlunparse
 
 import requests
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -191,16 +192,20 @@ class ISAPIClient:
             verify_ssl: Verify SSL certificates.
             rtsp_port: RTSP port for streaming (default 554).
         """
-        self.host = host
-        self.port = port
+        # Parse the host to extract clean hostname and handle URLs with scheme/port
+        protocol = "https" if ssl else "http"
+        parsed = urlparse(host if '://' in str(host) else f'{protocol}://{host}')
+        self.host = parsed.hostname or host
+        self.port = parsed.port or port
         self.username = username
         self.password = password
         self.ssl = ssl
         self.verify_ssl = verify_ssl
         self.rtsp_port = rtsp_port
 
-        protocol = "https" if ssl else "http"
-        self.base_url = f"{protocol}://{host}:{port}"
+        self.base_url = urlunparse((
+            protocol, f'{self.host}:{self.port}', '', '', '', ''
+        ))
 
         self._session = requests.Session()
         self._session.verify = verify_ssl
@@ -790,16 +795,21 @@ class ISAPIClient:
         """
         stream_id = channel * 100 + stream_type
         protocol = "rtsps" if self.ssl else "rtsp"
+        path = f"/Streaming/Channels/{stream_id}"
 
         if include_credentials:
-            return (
-                f"{protocol}://{self.username}:{self.password}@"
-                f"{self.host}:{self.rtsp_port}/Streaming/Channels/{stream_id}"
-            )
-        return (
-            f"{protocol}://{self.host}:{self.rtsp_port}"
-            f"/Streaming/Channels/{stream_id}"
-        )
+            encoded_user = quote(self.username, safe='')
+            encoded_pwd = quote(self.password, safe='')
+            return urlunparse((
+                protocol,
+                f'{encoded_user}:{encoded_pwd}@{self.host}:{self.rtsp_port}',
+                path, '', '', ''
+            ))
+        return urlunparse((
+            protocol,
+            f'{self.host}:{self.rtsp_port}',
+            path, '', '', ''
+        ))
 
     def reboot(self) -> None:
         """Reboot the device."""

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ from setuptools import setup
 setup(
     name='pyHik',
     packages=['pyhik'],
-    version='0.4.2',
+    version='0.4.3',
     description='Python API for Hikvision cameras and NVRs - event streaming, ISAPI access, and device control.',
     author='John Mihalic',
     author_email='mezz64@users.noreply.github.com',
     license='MIT',
     url='https://github.com/mezz64/pyhik',
-    download_url='https://github.com/mezz64/pyhik/tarball/0.4.2',
+    download_url='https://github.com/mezz64/pyhik/tarball/0.4.3',
     keywords=['hik', 'hikvision', 'event stream', 'events', 'api wrapper', 'homeassistant', 'isapi', 'nvr', 'camera'],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -48,7 +48,7 @@ class HikvisionTestCase(unittest.TestCase):
 
         session = args[-1].return_value
         get = session.get
-        url = "localhost:80/ISAPI/System/Video/inputs/channels/1/motionDetection"
+        url = "http://localhost:80/ISAPI/System/Video/inputs/channels/1/motionDetection"
 
         # Motion detection disabled
         self.set_motion_detection_state(get, False)
@@ -67,7 +67,8 @@ class HikvisionTestCase(unittest.TestCase):
         self.set_motion_detection_state(get, True)
         session.put.return_value = MagicMock(status_code=requests.codes.ok, ok=True)
         device.enable_motion_detection()
-        session.put.assert_called_once_with(url, data=XML.format("true").encode(), timeout=CONNECT_TIMEOUT)
+        put_url = "http://localhost:80/ISAPI/System/Video/inputs/channels/1/motionDetection"
+        session.put.assert_called_once_with(put_url, data=XML.format("true").encode(), timeout=CONNECT_TIMEOUT)
 
         # Disable
         def change_get_response(url, data,timeout):
@@ -239,6 +240,50 @@ class GetEventTriggersTestCase(unittest.TestCase):
         # Should find VMD on channels 1, 4, 5
         self.assertIn("VMD", events)
         self.assertEqual(sorted(events["VMD"]), [1, 4, 5])
+
+
+class URLParsingTestCase(unittest.TestCase):
+    """Test that URL parsing handles various host formats correctly."""
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.initialize")
+    def test_plain_host(self, mock_init, mock_session):
+        """Test host as plain IP address."""
+        camera = HikCamera(host="192.168.1.100", port=80)
+        self.assertEqual(camera.host, "192.168.1.100")
+        self.assertEqual(camera.root_url, "http://192.168.1.100:80")
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.initialize")
+    def test_host_with_scheme(self, mock_init, mock_session):
+        """Test host as URL with http scheme."""
+        camera = HikCamera(host="http://192.168.1.100", port=80)
+        self.assertEqual(camera.host, "192.168.1.100")
+        self.assertEqual(camera.root_url, "http://192.168.1.100:80")
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.initialize")
+    def test_host_with_scheme_and_port(self, mock_init, mock_session):
+        """Test host as URL with scheme and port - port in URL takes precedence."""
+        camera = HikCamera(host="http://192.168.1.100:8080", port=80)
+        self.assertEqual(camera.host, "192.168.1.100")
+        self.assertEqual(camera.root_url, "http://192.168.1.100:8080")
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.initialize")
+    def test_host_with_https(self, mock_init, mock_session):
+        """Test host with https scheme."""
+        camera = HikCamera(host="https://192.168.1.100", port=443)
+        self.assertEqual(camera.host, "192.168.1.100")
+        self.assertEqual(camera.root_url, "https://192.168.1.100:443")
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.initialize")
+    def test_hostname(self, mock_init, mock_session):
+        """Test with hostname instead of IP."""
+        camera = HikCamera(host="camera.local", port=80)
+        self.assertEqual(camera.host, "camera.local")
+        self.assertEqual(camera.root_url, "http://camera.local:80")
 
 
 class InjectEventsTestCase(unittest.TestCase):

--- a/test/test_isapi.py
+++ b/test/test_isapi.py
@@ -133,6 +133,38 @@ class TestISAPIClientBasics(unittest.TestCase):
             "rtsp://192.168.1.100:554/Streaming/Channels/101"
         )
 
+    def test_host_with_scheme(self):
+        """Test that host with http:// scheme is parsed correctly."""
+        client = ISAPIClient(host="http://192.168.1.100", port=80)
+        self.assertEqual(client.host, "192.168.1.100")
+        self.assertEqual(client.port, 80)
+        self.assertEqual(client.base_url, "http://192.168.1.100:80")
+
+    def test_host_with_scheme_and_port(self):
+        """Test that host with scheme and port extracts port from URL."""
+        client = ISAPIClient(host="http://192.168.1.100:8080", port=80)
+        self.assertEqual(client.host, "192.168.1.100")
+        self.assertEqual(client.port, 8080)
+        self.assertEqual(client.base_url, "http://192.168.1.100:8080")
+
+    def test_host_with_https_scheme(self):
+        """Test that host with https:// scheme is parsed correctly."""
+        client = ISAPIClient(host="https://192.168.1.100", port=443, ssl=True)
+        self.assertEqual(client.host, "192.168.1.100")
+        self.assertEqual(client.base_url, "https://192.168.1.100:443")
+
+    def test_rtsp_url_special_chars_in_password(self):
+        """Test that RTSP URL encodes special characters in credentials."""
+        client = ISAPIClient(
+            host="192.168.1.100",
+            username="admin",
+            password="p@ss:word/123",
+        )
+        url = client.get_rtsp_url(channel=1, stream_type=1)
+        self.assertIn("admin", url)
+        self.assertIn("p%40ss%3Aword%2F123", url)
+        self.assertNotIn("p@ss:word/123", url)
+
     def test_context_manager(self):
         """Test context manager usage."""
         with ISAPIClient(host="192.168.1.100") as client:


### PR DESCRIPTION
Replace manual string formatting with urlparse/urlunparse from the standard library for all URL construction. This properly handles hosts passed with or without scheme/port, encodes special characters in RTSP credentials, and avoids malformed URLs when host already contains a scheme or port number.

Bump version to 0.4.3.

Fixes raised in home-assistant/core#162092 review discussion.

https://claude.ai/code/session_01MD9zEtS2YRu9Gx8pGabpjQ