### PR TITLE
Add get_video_encryption() to check encryption status

### DIFF
--- a/pyhik/constants.py
+++ b/pyhik/constants.py
@@ -8,7 +8,7 @@ Licensed under the MIT license.
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 4
-SUB_MINOR_VERSION = 2
+SUB_MINOR_VERSION = 3
 __version__ = '{}.{}.{}'.format(
     MAJOR_VERSION, MINOR_VERSION, SUB_MINOR_VERSION)
 

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -39,7 +39,8 @@ from pyhik.constants import (
     DEFAULT_PORT, DEFAULT_RTSP_PORT, DEFAULT_HEADERS, XML_NAMESPACE, SENSOR_MAP,
     CAM_DEVICE, NVR_DEVICE, CONNECT_TIMEOUT, READ_TIMEOUT, SNAPSHOT_TIMEOUT,
     RECORDING_SEARCH_TIMEOUT, CONTEXT_INFO, CONTEXT_TRIG, CONTEXT_MOTION,
-    CONTEXT_ALERT, CHANNEL_NAMES, ID_TYPES, __version__)
+    CONTEXT_ALERT, CHANNEL_NAMES, ID_TYPES, VALID_NOTIFICATION_METHODS,
+    __version__)
 
 # Register the default namespace to avoid ns0: prefixes in serialized XML
 ET.register_namespace('', XML_NAMESPACE)
@@ -428,7 +429,7 @@ class HikCamera(object):
                 else:
                     self.cam_id = uuid.uuid4()
 
-        events_available = self.get_event_triggers()
+        events_available = self.get_event_triggers(VALID_NOTIFICATION_METHODS)
         if events_available:
             for event, channel_list in events_available.items():
                 for channel in channel_list:

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -254,6 +254,34 @@ class HikCamera(object):
 
         self.motion_detection = enable
 
+    def get_video_encryption(self):
+        """Check if video encryption is enabled on the device."""
+        url = '%s/ISAPI/Security/videoEncryption' % self.root_url
+
+        try:
+            response = self.hik_request.get(url, timeout=CONNECT_TIMEOUT)
+        except (requests.exceptions.RequestException,
+                requests.exceptions.ConnectionError) as err:
+            _LOGGING.debug('Unable to fetch videoEncryption, error: %s', err)
+            return None
+
+        if response.status_code != requests.codes.ok:
+            _LOGGING.debug('Video encryption endpoint not available.')
+            return None
+
+        try:
+            tree = ET.fromstring(response.text)
+        except ET.ParseError:
+            _LOGGING.debug('Unable to parse videoEncryption response.')
+            return None
+
+        # Look for <enabled> element in any namespace
+        for elem in tree.iter():
+            if elem.tag.rpartition('}')[2] == 'enabled':
+                return elem.text is not None and elem.text.lower() == 'true'
+
+        return None
+
     def get_snapshot(self, channel=1):
         """
         Fetch a snapshot image from the camera.

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ from setuptools import setup
 setup(
     name='pyHik',
     packages=['pyhik'],
-    version='0.4.2',
+    version='0.4.3',
     description='Python API for Hikvision cameras and NVRs - event streaming, ISAPI access, and device control.',
     author='John Mihalic',
     author_email='mezz64@users.noreply.github.com',
     license='MIT',
     url='https://github.com/mezz64/pyhik',
-    download_url='https://github.com/mezz64/pyhik/tarball/0.4.2',
+    download_url='https://github.com/mezz64/pyhik/tarball/0.4.3',
     keywords=['hik', 'hikvision', 'event stream', 'events', 'api wrapper', 'homeassistant', 'isapi', 'nvr', 'camera'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
## Summary

- Adds `get_video_encryption()` method to `HikCamera` that queries `/ISAPI/Security/videoEncryption`
- Returns `True` if encryption is enabled, `False` if disabled, `None` if the endpoint is not supported or an error occurs
- Follows the same pattern as `get_motion_detection()` for ISAPI queries and error handling

## Motivation

When video encryption is enabled on a Hikvision device (often via Hik-Connect/Platform Access), RTSP streams and snapshots return encrypted data that standard clients (including Home Assistant, Blue Iris, ZoneMinder) cannot decode. This causes black screens for camera streams.

This method allows the Home Assistant integration to detect encryption during setup and warn users with a repair issue, rather than silently showing broken streams.

Related: https://github.com/home-assistant/home-assistant.io/issues/44780

## Test plan

- [ ] Verify on a device with encryption enabled returns `True`
- [ ] Verify on a device with encryption disabled returns `False`
- [ ] Verify on a device without the endpoint (older firmware) returns `None`
- [ ] Verify network errors are handled gracefully (returns `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)