### PR TITLE
Fix event stream reliability, duplicate channels, log noise; add detection targets

### DIFF
--- a/pyhik/constants.py
+++ b/pyhik/constants.py
@@ -8,7 +8,7 @@ Licensed under the MIT license.
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 4
-SUB_MINOR_VERSION = 3
+SUB_MINOR_VERSION = 4
 __version__ = '{}.{}.{}'.format(
     MAJOR_VERSION, MINOR_VERSION, SUB_MINOR_VERSION)
 

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -154,6 +154,8 @@ class HikCamera(object):
         # Callbacks
         self._updateCallbacks = []
 
+        self._stream_connected = False
+
         self.initialize()
 
     @property
@@ -181,6 +183,25 @@ class HikCamera(object):
         """Return current state of motion detection property"""
         return self.motion_detection
 
+    @property
+    def stream_connected(self):
+        """Return True if the event stream is currently connected."""
+        return self._stream_connected
+
+    def _set_stream_connected(self, connected):
+        """Update stream connection state and notify callbacks on changes."""
+        if self._stream_connected == connected:
+            return
+        self._stream_connected = connected
+        if connected:
+            _LOGGING.info('%s event stream connected', self.name)
+        else:
+            _LOGGING.info('%s event stream disconnected', self.name)
+        # Notify every registered callback so consumers can update
+        # availability for all their sensors.
+        for callback, sensor in self._updateCallbacks:
+            callback(sensor)
+
     def get_motion_detection(self):
         """Fetch current motion state from camera"""
         url = ('%s/ISAPI/System/Video/inputs/'
@@ -207,19 +228,24 @@ class HikCamera(object):
 
         try:
             tree = ET.fromstring(response.text)
-            self.fetch_namespace(tree, CONTEXT_MOTION)
-            enabled = tree.find(self.element_query('enabled', CONTEXT_MOTION))
-
-            if enabled is not None:
-                self._motion_detection_xml = tree
-            self.motion_detection = {'true': True, 'false': False}[enabled.text]
-            return self.motion_detection
-
-        except AttributeError as err:
-            _LOGGING.error('Entire response: %s', response.text)
-            _LOGGING.error('There was a problem: %s', err)
+        except ET.ParseError as err:
+            _LOGGING.debug('Malformed motion detection response: %s', err)
             self.motion_detection = None
             return self.motion_detection
+
+        self.fetch_namespace(tree, CONTEXT_MOTION)
+        enabled = tree.find(self.element_query('enabled', CONTEXT_MOTION))
+
+        if enabled is None:
+            # NVRs and some cameras don't support this endpoint and return
+            # a different document. Not an error, just unsupported.
+            _LOGGING.debug('Device does not report motion detection state.')
+            self.motion_detection = None
+            return self.motion_detection
+
+        self._motion_detection_xml = tree
+        self.motion_detection = {'true': True, 'false': False}.get(enabled.text)
+        return self.motion_detection
 
     def enable_motion_detection(self):
         """Enable motion detection"""
@@ -438,19 +464,27 @@ class HikCamera(object):
         events_available = self.get_event_triggers(VALID_NOTIFICATION_METHODS)
         if events_available:
             for event, channel_list in events_available.items():
+                # Tracking videoloss events causes problems since they are used
+                # as the watchdog so ignore them if they are enabled in the triggers.
+                if event.lower() == 'videoloss':
+                    continue
+                try:
+                    etype = SENSOR_MAP[event.lower()]
+                except KeyError:
+                    # Sensor type doesn't have a known friendly name
+                    # We can't reliably handle it at this time...
+                    _LOGGING.warning(
+                        'Sensor type "%s" is unsupported.', event)
+                    continue
                 for channel in channel_list:
-                    try:
-                        # Tracking videoloss events causes problems since they are used
-                        # as the watchdog so ignore them if they are enabled in the triggers.
-                        if event.lower() != 'videoloss':
-                            self.event_states.setdefault(
-                                SENSOR_MAP[event.lower()], []).append(
-                                    [False, channel, 0, datetime.datetime.now()])
-                    except KeyError:
-                        # Sensor type doesn't have a known friendly name
-                        # We can't reliably handle it at this time...
-                        _LOGGING.warning(
-                            'Sensor type "%s" is unsupported.', event)
+                    entries = self.event_states.setdefault(etype, [])
+                    # Multiple raw event types can map to the same friendly
+                    # name (e.g. tamperdetection/shelteralarm/defocus), so
+                    # keep a single entry per (event, channel) pair.
+                    if any(entry[1] == channel for entry in entries):
+                        continue
+                    entries.append(
+                        [False, channel, 0, datetime.datetime.now(), None])
 
             _LOGGING.debug('Initialized Dictionary: %s', self.event_states)
         else:
@@ -566,10 +600,11 @@ class HikCamera(object):
             content = ET.fromstring(response.text)
             self.fetch_namespace(content, CONTEXT_TRIG)
 
-            if content[0].find(self.element_query('EventTrigger', CONTEXT_TRIG)):
+            if len(content) and content[0].find(
+                    self.element_query('EventTrigger', CONTEXT_TRIG)) is not None:
                 event_xml = content[0].findall(
                     self.element_query('EventTrigger', CONTEXT_TRIG))
-            elif content.find(self.element_query('EventTrigger', CONTEXT_TRIG)):
+            elif content.find(self.element_query('EventTrigger', CONTEXT_TRIG)) is not None:
                 # This is either an NVR or a rebadged camera
                 event_xml = content.findall(
                     self.element_query('EventTrigger', CONTEXT_TRIG))
@@ -600,7 +635,7 @@ class HikCamera(object):
                             # Field must not be an integer
                             pass
 
-                if etnotify:
+                if etnotify is not None:
                     for notifytrigger in etnotify:
                         ntype = notifytrigger.find(
                             self.element_query('notificationMethod', CONTEXT_TRIG))
@@ -609,8 +644,15 @@ class HikCamera(object):
                             # Found an event with a valid notification method
                             # Catch events with bad IDs
                             if etchannel_num == 0 : etchannel_num = 1
-                            events.setdefault(ettype.text, []) \
-                                .append(etchannel_num)
+                            channel_list = events.setdefault(ettype.text, [])
+                            # A trigger can carry several accepted notification
+                            # methods and a device can report the same event
+                            # type/channel in several triggers; only record
+                            # the channel once so each (event, channel) pair
+                            # yields a single sensor.
+                            if etchannel_num not in channel_list:
+                                channel_list.append(etchannel_num)
+                            break
 
         except (AttributeError, ET.ParseError) as err:
             _LOGGING.error(
@@ -666,13 +708,16 @@ class HikCamera(object):
                 if stream.status_code == requests.codes.not_found:
                     # Try alternate URL for stream
                     url = '%s/Event/notification/alertStream' % self.root_url
-                    stream = self.hik_request_stream.get(url, stream=True)
+                    stream = self.hik_request_stream.get(url, stream=True,
+                                                         timeout=(CONNECT_TIMEOUT,
+                                                                  READ_TIMEOUT))
 
                 if stream.status_code != requests.codes.ok:
                     raise ValueError('Connection unsucessful.')
                 else:
                     _LOGGING.debug('%s Connection Successful.', self.name)
                     fail_count = 0
+                    self._set_stream_connected(True)
                     self.watchdog.start()
 
                 for line in stream.iter_lines():
@@ -712,6 +757,7 @@ class HikCamera(object):
                     # We were asked to stop the thread so lets do so.
                     _LOGGING.debug('Stopping event stream thread for %s',
                                    self.name)
+                    self._set_stream_connected(False)
                     self.watchdog.stop()
                     self.hik_request_stream.close()
                     return
@@ -719,11 +765,19 @@ class HikCamera(object):
                     # We need to reset the connection.
                     raise ValueError('Watchdog failed.')
 
+            # RequestException also covers read timeouts, which happen when
+            # the connection silently drops; without catching them here the
+            # stream thread would die and events would stop forever.
             except (ValueError,
-                    requests.exceptions.ConnectionError,
-                    requests.exceptions.ChunkedEncodingError) as err:
+                    requests.exceptions.RequestException) as err:
                 fail_count += 1
+                watchdog_reset = reset_event.is_set()
                 reset_event.clear()
+                # A watchdog reset is routine maintenance on a quiet stream;
+                # only flag the stream as down once a reconnect also fails
+                # or the failure came from the connection itself.
+                if not watchdog_reset or fail_count > 1:
+                    self._set_stream_connected(False)
                 _LOGGING.warning('%s Connection Failed (count=%d). Waiting %ss. Err: %s',
                                  self.name, fail_count, (fail_count * 5) + 5, err)
                 parse_string = ""
@@ -767,6 +821,15 @@ class HikCamera(object):
             _LOGGING.error('Problem finding attribute: %s', err)
             return
 
+        # Optional smart-event detection target (e.g. human/vehicle). It can
+        # appear at the top level or nested in a detection region entry.
+        etarget = tree.find(
+            './/%s' % self.element_query('targetType', CONTEXT_ALERT))
+        if etarget is None:
+            etarget = tree.find(
+                './/%s' % self.element_query('detectionTarget', CONTEXT_ALERT))
+        target_type = etarget.text if etarget is not None else None
+
         # Take care of keep-alive
         if len(etype) > 0 and etype == 'Video Loss':
             self.watchdog.pet()
@@ -780,7 +843,7 @@ class HikCamera(object):
                 estate = (estate == 'active')
                 old_state = state[0]
                 attr = [estate, echid, int(ecount),
-                        datetime.datetime.now()]
+                        datetime.datetime.now(), target_type]
                 self.update_attributes(etype, echid, attr)
 
                 if estate != old_state:
@@ -801,8 +864,11 @@ class HikCamera(object):
                     if sec_elap > 5 and eprop[0] is True:
                         _LOGGING.debug('Updating stale event %s on CH(%s)',
                                        etype, eprop[1])
+                        # Keep the last detection target so consumers can
+                        # pair it with the last tripped time.
                         attr = [False, eprop[1], eprop[2],
-                                datetime.datetime.now()]
+                                datetime.datetime.now(),
+                                eprop[4] if len(eprop) > 4 else None]
                         self.update_attributes(etype, eprop[1], attr)
                         self.publish_changes(etype, eprop[1])
 
@@ -857,9 +923,10 @@ class HikCamera(object):
                     sensor[1] == channel for sensor in self.event_states[event_name]
                 )
                 if not channel_exists:
-                    # Add the event state: [is_active, channel, count, last_update_time]
+                    # Add the event state:
+                    # [is_active, channel, count, last_update_time, target_type]
                     self.event_states[event_name].append(
-                        [False, channel, 0, datetime.datetime.now()]
+                        [False, channel, 0, datetime.datetime.now(), None]
                     )
 
     def get_recording_days(self, track_id, start_date, end_date):

--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -473,7 +473,7 @@ class HikCamera(object):
                 except KeyError:
                     # Sensor type doesn't have a known friendly name
                     # We can't reliably handle it at this time...
-                    _LOGGING.warning(
+                    _LOGGING.debug(
                         'Sensor type "%s" is unsupported.', event)
                     continue
                 for channel in channel_list:
@@ -794,13 +794,21 @@ class HikCamera(object):
             self.fetch_namespace(tree, CONTEXT_ALERT)
 
         try:
-            etype = SENSOR_MAP[tree.find(
-                self.element_query('eventType', CONTEXT_ALERT)).text.lower()]
-            
+            raw_etype = tree.find(
+                self.element_query('eventType', CONTEXT_ALERT)).text
+            try:
+                etype = SENSOR_MAP[raw_etype.lower()]
+            except KeyError:
+                # Event type we don't model (e.g. storageDetection); skip
+                # quietly rather than logging an error for every packet.
+                _LOGGING.debug('Unsupported event type "%s", ignoring.',
+                               raw_etype)
+                return
+
             # Since this pasing is different and not really usefull for now, just return without error.
             if len(etype) > 0 and etype == 'Ongoing Events':
                 return
-            
+
             estate = tree.find(
                 self.element_query('eventState', CONTEXT_ALERT)).text
 

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ from setuptools import setup
 setup(
     name='pyHik',
     packages=['pyhik'],
-    version='0.4.3',
+    version='0.4.4',
     description='Python API for Hikvision cameras and NVRs - event streaming, ISAPI access, and device control.',
     author='John Mihalic',
     author_email='mezz64@users.noreply.github.com',
     license='MIT',
     url='https://github.com/mezz64/pyhik',
-    download_url='https://github.com/mezz64/pyhik/tarball/0.4.3',
+    download_url='https://github.com/mezz64/pyhik/tarball/0.4.4',
     keywords=['hik', 'hikvision', 'event stream', 'events', 'api wrapper', 'homeassistant', 'isapi', 'nvr', 'camera'],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -532,6 +532,25 @@ class DuplicateEventsTestCase(unittest.TestCase):
         self.assertEqual(sorted(tamper_channels), [1, 2])
         self.assertEqual(len(camera.event_states["Motion"]), 1)
 
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.get_device_info")
+    @patch("pyhik.hikvision.HikCamera.get_event_triggers")
+    def test_initialize_skips_unsupported_types_quietly(
+            self, mock_triggers, mock_info, mock_session):
+        """Event types missing from SENSOR_MAP are skipped at debug level
+        instead of warning on every startup (home-assistant/core#174797)."""
+        mock_info.return_value = {"deviceName": "Test", "deviceID": "12345678901"}
+        mock_triggers.return_value = {"storageDetection": [1], "VMD": [1]}
+        session = mock_session.return_value
+        session.get.return_value = MagicMock(
+            status_code=requests.codes.not_found)
+
+        with self.assertNoLogs("pyhik.hikvision", level=logging.WARNING):
+            camera = HikCamera(host="localhost")
+
+        self.assertEqual(set(camera.event_states), {"Motion"})
+        self.assertEqual(len(camera.event_states["Motion"]), 1)
+
 
 ALERT_XML = """<EventNotificationAlert \
 xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
@@ -590,6 +609,19 @@ class ProcessStreamTestCase(unittest.TestCase):
         camera.process_stream(tree)
 
         self.assertIsNone(camera.fetch_attributes("Motion", 1)[4])
+
+    def test_process_stream_ignores_unsupported_event_type(self):
+        """Unknown event types on the alert stream are dropped without an
+        error log."""
+        camera = self._make_camera()
+        tree = ET.fromstring(ALERT_XML.format(extra="").replace(
+            "<eventType>VMD</eventType>",
+            "<eventType>storageDetection</eventType>"))
+
+        with self.assertNoLogs("pyhik.hikvision", level=logging.ERROR):
+            camera.process_stream(tree)
+
+        self.assertFalse(camera.fetch_attributes("Motion", 1)[0])
 
 
 class StreamConnectedTestCase(unittest.TestCase):

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -3,6 +3,7 @@
 import logging
 import requests
 import unittest
+import xml.etree.ElementTree as ET
 
 from unittest.mock import MagicMock, patch, PropertyMock
 from requests.auth import HTTPDigestAuth
@@ -64,8 +65,27 @@ class HikvisionTestCase(unittest.TestCase):
         self.assertIsNotNone(device)
         self.assertTrue(device.current_motion_detection_state)
 
+        # Unsupported devices (e.g. NVRs) return a document without an
+        # 'enabled' element; this must not raise or log an error.
+        get.reset_mock()
+        mock = get.return_value
+        type(mock).ok = PropertyMock(return_value=True)
+        type(mock).status_code = PropertyMock(return_value=requests.codes.ok)
+        type(mock).text = PropertyMock(
+            return_value='<SomeOtherDocument '
+                         'xmlns="http://www.hikvision.com/ver20/XMLSchema"/>'
+        )
+        unsupported_device = HikCamera(host="localhost")
+        self.assertIsNone(unsupported_device.current_motion_detection_state)
+
+        # Non-XML responses must not raise either.
+        type(mock).text = PropertyMock(return_value='not xml at all')
+        unsupported_device = HikCamera(host="localhost")
+        self.assertIsNone(unsupported_device.current_motion_detection_state)
+
         # Enable calls put with the expected data
         self.set_motion_detection_state(get, True)
+        device = HikCamera(host="localhost")
         session.put.return_value = MagicMock(status_code=requests.codes.ok, ok=True)
         device.enable_motion_detection()
         session.put.assert_called_once_with(url, data=XML.format("true").encode(), timeout=CONNECT_TIMEOUT)
@@ -430,6 +450,171 @@ class ThreadSafetyTestCase(unittest.TestCase):
 
         # API session should NOT be closed
         api_session.close.assert_not_called()
+# XML with one trigger carrying several accepted notification methods and a
+# second trigger repeating the same event type and channel.
+DUPLICATE_TRIGGERS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<EventTriggerList xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
+    <EventTrigger version="2.0">
+        <id>1</id>
+        <eventType>VMD</eventType>
+        <videoInputChannelID>1</videoInputChannelID>
+        <EventTriggerNotificationList>
+            <EventTriggerNotification>
+                <id>1</id>
+                <notificationMethod>center</notificationMethod>
+            </EventTriggerNotification>
+            <EventTriggerNotification>
+                <id>2</id>
+                <notificationMethod>HTTP</notificationMethod>
+            </EventTriggerNotification>
+            <EventTriggerNotification>
+                <id>3</id>
+                <notificationMethod>record</notificationMethod>
+            </EventTriggerNotification>
+        </EventTriggerNotificationList>
+    </EventTrigger>
+    <EventTrigger version="2.0">
+        <id>2</id>
+        <eventType>VMD</eventType>
+        <videoInputChannelID>1</videoInputChannelID>
+        <EventTriggerNotificationList>
+            <EventTriggerNotification>
+                <id>1</id>
+                <notificationMethod>HTTP</notificationMethod>
+            </EventTriggerNotification>
+        </EventTriggerNotificationList>
+    </EventTrigger>
+</EventTriggerList>"""
+
+
+class DuplicateEventsTestCase(unittest.TestCase):
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.get_device_info")
+    def test_get_event_triggers_deduplicates_channels(
+            self, mock_info, mock_session):
+        """A channel is reported once per event type regardless of how many
+        notification methods or duplicate triggers reference it."""
+        mock_info.return_value = {"deviceName": "Test", "deviceID": "12345678901"}
+        session = mock_session.return_value
+        response = MagicMock()
+        response.status_code = requests.codes.ok
+        response.text = DUPLICATE_TRIGGERS_XML
+        session.get.return_value = response
+
+        camera = HikCamera(host="localhost")
+        events = camera.get_event_triggers(
+            notification_methods=VALID_NOTIFICATION_METHODS)
+
+        self.assertEqual(events["VMD"], [1])
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.get_device_info")
+    @patch("pyhik.hikvision.HikCamera.get_event_triggers")
+    def test_initialize_deduplicates_sensor_map_collisions(
+            self, mock_triggers, mock_info, mock_session):
+        """Raw event types mapping to the same friendly name must yield a
+        single state entry per channel."""
+        mock_info.return_value = {"deviceName": "Test", "deviceID": "12345678901"}
+        mock_triggers.return_value = {
+            "tamperdetection": [1],
+            "shelteralarm": [1, 2],
+            "defocus": [1],
+            "VMD": [1],
+        }
+        session = mock_session.return_value
+        session.get.return_value = MagicMock(
+            status_code=requests.codes.not_found)
+
+        camera = HikCamera(host="localhost")
+
+        tamper_channels = [
+            entry[1] for entry in camera.event_states["Tamper Detection"]]
+        self.assertEqual(sorted(tamper_channels), [1, 2])
+        self.assertEqual(len(camera.event_states["Motion"]), 1)
+
+
+ALERT_XML = """<EventNotificationAlert \
+xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
+<ipAddress>192.168.1.100</ipAddress>
+<protocolType>HTTP</protocolType>
+<channelID>1</channelID>
+<dateTime>2026-06-08T12:00:00+00:00</dateTime>
+<activePostCount>1</activePostCount>
+<eventType>VMD</eventType>
+<eventState>active</eventState>
+<eventDescription>Motion alarm</eventDescription>
+{extra}
+</EventNotificationAlert>"""
+
+
+class ProcessStreamTestCase(unittest.TestCase):
+    @staticmethod
+    def _make_camera():
+        with patch("pyhik.hikvision.requests.Session") as mock_session, \
+                patch("pyhik.hikvision.HikCamera.get_device_info") as mock_info, \
+                patch("pyhik.hikvision.HikCamera.get_event_triggers") as mock_triggers:
+            mock_info.return_value = {
+                "deviceName": "Test", "deviceID": "12345678901"}
+            mock_triggers.return_value = {"VMD": [1]}
+            session = mock_session.return_value
+            session.get.return_value = MagicMock(
+                status_code=requests.codes.not_found)
+            return HikCamera(host="localhost")
+
+    def test_process_stream_parses_target_type(self):
+        """targetType from the alert XML is exposed in the attributes."""
+        camera = self._make_camera()
+        tree = ET.fromstring(
+            ALERT_XML.format(extra="<targetType>human</targetType>"))
+        camera.process_stream(tree)
+
+        attributes = camera.fetch_attributes("Motion", 1)
+        self.assertTrue(attributes[0])
+        self.assertEqual(attributes[4], "human")
+
+    def test_process_stream_parses_nested_detection_target(self):
+        """detectionTarget nested in a region entry is used as fallback."""
+        camera = self._make_camera()
+        tree = ET.fromstring(ALERT_XML.format(
+            extra="<DetectionRegionList><DetectionRegionEntry>"
+                  "<detectionTarget>vehicle</detectionTarget>"
+                  "</DetectionRegionEntry></DetectionRegionList>"))
+        camera.process_stream(tree)
+
+        self.assertEqual(camera.fetch_attributes("Motion", 1)[4], "vehicle")
+
+    def test_process_stream_without_target_type(self):
+        """Alerts without a detection target leave the attribute as None."""
+        camera = self._make_camera()
+        tree = ET.fromstring(ALERT_XML.format(extra=""))
+        camera.process_stream(tree)
+
+        self.assertIsNone(camera.fetch_attributes("Motion", 1)[4])
+
+
+class StreamConnectedTestCase(unittest.TestCase):
+    def test_set_stream_connected_notifies_all_callbacks(self):
+        """Connection state changes notify every registered callback once."""
+        camera = ProcessStreamTestCase._make_camera()
+        motion_callback = MagicMock()
+        tamper_callback = MagicMock()
+        camera.add_update_callback(motion_callback, "id.Motion.1")
+        camera.add_update_callback(tamper_callback, "id.Tamper Detection.1")
+
+        self.assertFalse(camera.stream_connected)
+
+        camera._set_stream_connected(True)
+        self.assertTrue(camera.stream_connected)
+        motion_callback.assert_called_once_with("id.Motion.1")
+        tamper_callback.assert_called_once_with("id.Tamper Detection.1")
+
+        # No change, no extra notifications
+        camera._set_stream_connected(True)
+        motion_callback.assert_called_once_with("id.Motion.1")
+
+        camera._set_stream_connected(False)
+        self.assertFalse(camera.stream_connected)
+        self.assertEqual(motion_callback.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes for the issues users have reported against the Home Assistant hikvision integration since the 0.4.3 bump, on the pyhik side:

- **Duplicate channels** (home-assistant/core#174798): `get_event_triggers` no longer records the same channel once per matching notification method (or per duplicate trigger), and `initialize()` keeps a single state entry per (event, channel) pair even when several raw event types map to the same friendly name (`tamperdetection`/`shelteralarm`/`defocus` → "Tamper Detection"). Duplicate entries caused "Platform hikvision does not generate unique IDs" errors in Home Assistant. (HA has since added a defensive dedupe on its side, but fixing it at the source helps every consumer.)
- **Unsupported sensor type log spam** (home-assistant/core#174797): now that 0.4.3 discovers events on all notification methods, NVRs surface event types like `storageDetection` that have no `SENSOR_MAP` entry, and every startup logged `Sensor type "storageDetection" is unsupported.` as a warning. These are now skipped at debug level, in `initialize()` and in the alert stream.
- **Events stopping permanently** (home-assistant/core#173869): `alert_stream` now catches all `requests` exceptions, including read timeouts, so a silently dropped connection no longer kills the stream thread. The alternate stream URL request also gets a timeout.
- **Noisy motion detection errors** (home-assistant/core#165422): `get_motion_detection` handles devices that don't support the endpoint (e.g. NVRs) without logging `'NoneType' object has no attribute 'text'` errors.
- **Detection target** (home-assistant/core#173251): parse the smart event detection target (`targetType`/`detectionTarget`, e.g. human or vehicle) from event alerts and expose it as a fifth element of the attribute list so consumers can distinguish person/vehicle detections.
- **Stream connection state**: track and expose `stream_connected`, notifying registered callbacks on changes, so consumers can mark entities unavailable while the device is unreachable (home-assistant/core#173174).
- Fix `Element` truthiness checks in `get_event_triggers` that relied on deprecated behavior.
- Bump version to 0.4.4.

Tests added for the dedupe behavior, unsupported-type skipping, detection targets, and connection-state callbacks; full suite passes (40 tests).

Happy to split this into smaller PRs if you'd prefer. Once released, I'll bump the requirement in Home Assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJPeWozGgPZSwLpPwjNTHf
