### PR TITLE
Stop logging unsupported sensor types as errors

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -481,19 +481,22 @@ class HikCamera(object):
         events_available = self.get_event_triggers(VALID_NOTIFICATION_METHODS)
         if events_available:
             for event, channel_list in events_available.items():
+                # Tracking videoloss events causes problems since they are used
+                # as the watchdog so ignore them if they are enabled in the triggers.
+                if event.lower() == 'videoloss':
+                    continue
+                try:
+                    etype = SENSOR_MAP[event.lower()]
+                except KeyError:
+                    # Sensor type doesn't have a known friendly name
+                    # We can't reliably handle it at this time...
+                    # Devices legitimately report types we don't model, so
+                    # this is normal for the user and not a warning.
+                    _LOGGING.debug('Sensor type "%s" is unsupported.', event)
+                    continue
                 for channel in channel_list:
-                    try:
-                        # Tracking videoloss events causes problems since they are used
-                        # as the watchdog so ignore them if they are enabled in the triggers.
-                        if event.lower() != 'videoloss':
-                            self.event_states.setdefault(
-                                SENSOR_MAP[event.lower()], []).append(
-                                    [False, channel, 0, datetime.datetime.now()])
-                    except KeyError:
-                        # Sensor type doesn't have a known friendly name
-                        # We can't reliably handle it at this time...
-                        _LOGGING.warning(
-                            'Sensor type "%s" is unsupported.', event)
+                    self.event_states.setdefault(etype, []).append(
+                        [False, channel, 0, datetime.datetime.now()])
 
             _LOGGING.debug('Initialized Dictionary: %s', self.event_states)
         else:
@@ -783,9 +786,17 @@ class HikCamera(object):
             self.fetch_namespace(tree, CONTEXT_ALERT)
 
         try:
-            etype = SENSOR_MAP[tree.find(
-                self.element_query('eventType', CONTEXT_ALERT)).text.lower()]
-            
+            raw_etype = tree.find(
+                self.element_query('eventType', CONTEXT_ALERT)).text
+            try:
+                etype = SENSOR_MAP[raw_etype.lower()]
+            except KeyError:
+                # Event type we don't model (e.g. storageDetection); skip
+                # quietly rather than logging an error for every packet.
+                _LOGGING.debug('Unsupported event type "%s", ignoring.',
+                               raw_etype)
+                return
+
             # Since this pasing is different and not really usefull for now, just return without error.
             if len(etype) > 0 and etype == 'Ongoing Events':
                 return

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -3,6 +3,7 @@
 import logging
 import requests
 import unittest
+import xml.etree.ElementTree as ET
 
 from unittest.mock import call, MagicMock, patch, PropertyMock
 from requests.auth import HTTPDigestAuth
@@ -532,6 +533,58 @@ class ThreadSafetyTestCase(unittest.TestCase):
 
         # API session should NOT be closed
         api_session.close.assert_not_called()
+
+
+ALERT_XML = """<EventNotificationAlert \
+xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
+<ipAddress>192.168.1.100</ipAddress>
+<protocolType>HTTP</protocolType>
+<channelID>1</channelID>
+<dateTime>2026-06-08T12:00:00+00:00</dateTime>
+<activePostCount>1</activePostCount>
+<eventType>{etype}</eventType>
+<eventState>active</eventState>
+<eventDescription>Motion alarm</eventDescription>
+</EventNotificationAlert>"""
+
+
+def make_camera(triggers=None):
+    """Build a HikCamera with a stubbed device and event trigger list."""
+    with patch("pyhik.hikvision.requests.Session") as mock_session, \
+            patch("pyhik.hikvision.HikCamera.get_device_info") as mock_info, \
+            patch("pyhik.hikvision.HikCamera.get_event_triggers") as mock_triggers:
+        mock_info.return_value = {
+            "deviceName": "Test", "deviceID": "12345678901"}
+        mock_triggers.return_value = triggers if triggers is not None else {"VMD": [1]}
+        mock_session.return_value.get.return_value = MagicMock(
+            status_code=requests.codes.not_found)
+        return HikCamera(host="localhost")
+
+
+class UnsupportedSensorTypeTestCase(unittest.TestCase):
+    """Devices report event types pyHik doesn't model; that is normal and
+    must not log a warning on every startup or an error on every packet."""
+
+    def test_initialize_skips_unsupported_types_quietly(self):
+        with self.assertNoLogs("pyhik.hikvision", level=logging.WARNING):
+            camera = make_camera({"storageDetection": [1], "VMD": [1]})
+
+        self.assertEqual(set(camera.event_states), {"Motion"})
+
+    def test_process_stream_ignores_unsupported_event_type(self):
+        camera = make_camera()
+        tree = ET.fromstring(ALERT_XML.format(etype="storageDetection"))
+
+        with self.assertNoLogs("pyhik.hikvision", level=logging.ERROR):
+            camera.process_stream(tree)
+
+        self.assertFalse(camera.fetch_attributes("Motion", 1)[0])
+
+    def test_process_stream_still_handles_known_event_type(self):
+        camera = make_camera()
+        camera.process_stream(ET.fromstring(ALERT_XML.format(etype="VMD")))
+
+        self.assertTrue(camera.fetch_attributes("Motion", 1)[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Split out of #121 — the log noise piece first, as requested.

Now that 0.4.3 discovers events on all notification methods, devices surface event types that have no `SENSOR_MAP` entry — `storageDetection` is the one users keep hitting. `initialize()` logged a warning for every such type on every startup, and `process_stream()` logged a `Problem finding attribute` error for every packet of one.

A device reporting a type pyHik doesn't model is normal, so both are now skipped at debug level. The `SENSOR_MAP` lookup in `initialize()` also moves out of the per-channel loop, so it runs once per event type rather than once per channel.

Reported in home-assistant/core#174797, and by @blue-bean on #121.

Nothing else changes: the same state entries are created as before.

Three tests added. Heads up that master is currently red independently of this — `test_snapshot_uses_api_session` and `test_auth_detection_digest` both fail on 02c3d07. Happy to send a separate PR for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
