### PR TITLE
Record each (event, channel) pair once

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -495,8 +495,14 @@ class HikCamera(object):
                     _LOGGING.debug('Sensor type "%s" is unsupported.', event)
                     continue
                 for channel in channel_list:
-                    self.event_states.setdefault(etype, []).append(
-                        [False, channel, 0, datetime.datetime.now()])
+                    # Several raw event types can map to the same friendly
+                    # name (tamperdetection, shelteralarm and defocus all mean
+                    # "Tamper Detection"), so keep a single entry per
+                    # (event, channel) pair.
+                    entries = self.event_states.setdefault(etype, [])
+                    if not any(entry[1] == channel for entry in entries):
+                        entries.append(
+                            [False, channel, 0, datetime.datetime.now()])
 
             _LOGGING.debug('Initialized Dictionary: %s', self.event_states)
         else:
@@ -612,10 +618,11 @@ class HikCamera(object):
             content = ET.fromstring(response.text)
             self.fetch_namespace(content, CONTEXT_TRIG)
 
-            if content[0].find(self.element_query('EventTrigger', CONTEXT_TRIG)):
+            if len(content) and content[0].find(
+                    self.element_query('EventTrigger', CONTEXT_TRIG)) is not None:
                 event_xml = content[0].findall(
                     self.element_query('EventTrigger', CONTEXT_TRIG))
-            elif content.find(self.element_query('EventTrigger', CONTEXT_TRIG)):
+            elif content.find(self.element_query('EventTrigger', CONTEXT_TRIG)) is not None:
                 # This is either an NVR or a rebadged camera
                 event_xml = content.findall(
                     self.element_query('EventTrigger', CONTEXT_TRIG))
@@ -646,7 +653,7 @@ class HikCamera(object):
                             # Field must not be an integer
                             pass
 
-                if etnotify:
+                if etnotify is not None:
                     for notifytrigger in etnotify:
                         ntype = notifytrigger.find(
                             self.element_query('notificationMethod', CONTEXT_TRIG))
@@ -655,8 +662,15 @@ class HikCamera(object):
                             # Found an event with a valid notification method
                             # Catch events with bad IDs
                             if etchannel_num == 0 : etchannel_num = 1
-                            events.setdefault(ettype.text, []) \
-                                .append(etchannel_num)
+                            channel_list = events.setdefault(ettype.text, [])
+                            # A trigger can carry several accepted notification
+                            # methods, and a device can report the same event
+                            # type and channel in several triggers. Record the
+                            # channel once so each (event, channel) pair yields
+                            # a single sensor.
+                            if etchannel_num not in channel_list:
+                                channel_list.append(etchannel_num)
+                            break
 
         except (AttributeError, ET.ParseError) as err:
             _LOGGING.error(

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -587,5 +587,77 @@ class UnsupportedSensorTypeTestCase(unittest.TestCase):
         self.assertTrue(camera.fetch_attributes("Motion", 1)[0])
 
 
+# One trigger carrying several accepted notification methods, and a second
+# trigger repeating the same event type and channel.
+DUPLICATE_TRIGGERS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<EventTriggerList xmlns="http://www.hikvision.com/ver20/XMLSchema" version="2.0">
+    <EventTrigger version="2.0">
+        <id>1</id>
+        <eventType>VMD</eventType>
+        <videoInputChannelID>1</videoInputChannelID>
+        <EventTriggerNotificationList>
+            <EventTriggerNotification>
+                <id>1</id>
+                <notificationMethod>center</notificationMethod>
+            </EventTriggerNotification>
+            <EventTriggerNotification>
+                <id>2</id>
+                <notificationMethod>HTTP</notificationMethod>
+            </EventTriggerNotification>
+            <EventTriggerNotification>
+                <id>3</id>
+                <notificationMethod>record</notificationMethod>
+            </EventTriggerNotification>
+        </EventTriggerNotificationList>
+    </EventTrigger>
+    <EventTrigger version="2.0">
+        <id>2</id>
+        <eventType>VMD</eventType>
+        <videoInputChannelID>1</videoInputChannelID>
+        <EventTriggerNotificationList>
+            <EventTriggerNotification>
+                <id>1</id>
+                <notificationMethod>HTTP</notificationMethod>
+            </EventTriggerNotification>
+        </EventTriggerNotificationList>
+    </EventTrigger>
+</EventTriggerList>"""
+
+
+class DuplicateChannelsTestCase(unittest.TestCase):
+    """Duplicate (event, channel) pairs made Home Assistant reject the whole
+    platform with "does not generate unique IDs"."""
+
+    @patch("pyhik.hikvision.requests.Session")
+    @patch("pyhik.hikvision.HikCamera.get_device_info")
+    def test_get_event_triggers_deduplicates_channels(
+            self, mock_info, mock_session):
+        mock_info.return_value = {
+            "deviceName": "Test", "deviceID": "12345678901"}
+        response = MagicMock()
+        response.status_code = requests.codes.ok
+        response.text = DUPLICATE_TRIGGERS_XML
+        mock_session.return_value.get.return_value = response
+
+        camera = HikCamera(host="localhost")
+        events = camera.get_event_triggers(
+            notification_methods=VALID_NOTIFICATION_METHODS)
+
+        self.assertEqual(events["VMD"], [1])
+
+    def test_initialize_deduplicates_sensor_map_collisions(self):
+        camera = make_camera({
+            "tamperdetection": [1],
+            "shelteralarm": [1, 2],
+            "defocus": [1],
+            "VMD": [1],
+        })
+
+        tamper_channels = [
+            entry[1] for entry in camera.event_states["Tamper Detection"]]
+        self.assertEqual(sorted(tamper_channels), [1, 2])
+        self.assertEqual(len(camera.event_states["Motion"]), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Split out of #121.

`get_event_triggers()` appended the channel once per accepted notification method on a trigger, and again for every trigger repeating the same event type and channel — so a device with `center`/`HTTP`/`record` enabled reported the same channel three times. `initialize()` then created one state entry per occurrence, and separately created several entries for one channel when different raw event types map to the same friendly name (`tamperdetection`, `shelteralarm` and `defocus` all mean "Tamper Detection").

Both now keep a single entry per (event, channel) pair. Home Assistant rejected the whole platform with `Platform hikvision does not generate unique IDs` when they collided — home-assistant/core#174798. HA has since added a defensive dedupe of its own, but fixing it at the source helps every consumer.

This also fixes two Element truthiness checks in `get_event_triggers` that rely on deprecated behaviour: an `Element` with no children is falsy, so `if content[0].find(...)` skipped a trigger list whose `EventTrigger` has no child elements. Both are now explicit `is not None` checks. Happy to pull that into its own PR if you'd rather.

Two tests added. This touches `initialize()` in the same place as #122, so whichever you merge first I'll rebase the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
