### PR TITLE
Keep the event stream alive through read timeouts

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -726,7 +726,9 @@ class HikCamera(object):
                 if stream.status_code == requests.codes.not_found:
                     # Try alternate URL for stream
                     url = '%s/Event/notification/alertStream' % self.root_url
-                    stream = self.hik_request_stream.get(url, stream=True)
+                    stream = self.hik_request_stream.get(url, stream=True,
+                                                         timeout=(CONNECT_TIMEOUT,
+                                                                  READ_TIMEOUT))
 
                 if stream.status_code != requests.codes.ok:
                     raise ValueError('Connection unsucessful.')
@@ -779,9 +781,12 @@ class HikCamera(object):
                     # We need to reset the connection.
                     raise ValueError('Watchdog failed.')
 
+            # RequestException is the base class of every requests error and
+            # covers read timeouts, which is how a silently dropped connection
+            # surfaces. Anything not caught here kills the stream thread and
+            # events stop for good until the integration is reloaded.
             except (ValueError,
-                    requests.exceptions.ConnectionError,
-                    requests.exceptions.ChunkedEncodingError) as err:
+                    requests.exceptions.RequestException) as err:
                 fail_count += 1
                 reset_event.clear()
                 _LOGGING.warning('%s Connection Failed (count=%d). Waiting %ss. Err: %s',

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -2,6 +2,7 @@
 
 import logging
 import requests
+import threading
 import unittest
 import xml.etree.ElementTree as ET
 
@@ -657,6 +658,42 @@ class DuplicateChannelsTestCase(unittest.TestCase):
             entry[1] for entry in camera.event_states["Tamper Detection"]]
         self.assertEqual(sorted(tamper_channels), [1, 2])
         self.assertEqual(len(camera.event_states["Motion"]), 1)
+
+
+class StopLoop(Exception):
+    """Raised from a patched sleep to leave alert_stream's endless loop."""
+
+
+class StreamReliabilityTestCase(unittest.TestCase):
+    @patch("pyhik.hikvision.time.sleep")
+    def test_read_timeout_does_not_kill_the_thread(self, mock_sleep):
+        """A read timeout is how a silently dropped connection surfaces. If it
+        escapes the loop the thread dies and events stop for good."""
+        camera = make_camera()
+        camera.hik_request_stream = MagicMock()
+        camera.hik_request_stream.get.side_effect = \
+            requests.exceptions.ReadTimeout("read timed out")
+        # Leave the retry loop rather than sleeping through the backoff.
+        mock_sleep.side_effect = [None, StopLoop]
+
+        with self.assertRaises(StopLoop):
+            camera.alert_stream(threading.Event(), threading.Event())
+
+    @patch("pyhik.hikvision.time.sleep")
+    def test_alternate_stream_url_has_a_timeout(self, mock_sleep):
+        """Without a timeout the fallback request can block the thread
+        forever on a device that accepts the connection and never answers."""
+        camera = make_camera()
+        camera.hik_request_stream = MagicMock()
+        camera.hik_request_stream.get.return_value = MagicMock(
+            status_code=requests.codes.not_found)
+        mock_sleep.side_effect = [None, StopLoop]
+
+        with self.assertRaises(StopLoop):
+            camera.alert_stream(threading.Event(), threading.Event())
+
+        alternate_call = camera.hik_request_stream.get.call_args_list[1]
+        self.assertIn("timeout", alternate_call.kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Split out of #121.

`alert_stream()` only caught `ConnectionError` and `ChunkedEncodingError`. A **read timeout** — which is how a silently dropped connection surfaces, and the stream already passes `READ_TIMEOUT` — escaped the retry loop and killed the stream thread, so events stopped permanently until the consumer reloaded the device. This catches `requests.exceptions.RequestException`, the base class of every requests error, so no requests failure can take the thread down.

The fallback `/Event/notification/alertStream` request also had no timeout, so a device that accepts the connection and never answers could block the thread forever. It now gets the same `(CONNECT_TIMEOUT, READ_TIMEOUT)` as the primary URL.

Reported in home-assistant/core#173869 — several people there describe events working for hours or days and then stopping until a reload.

Two tests added; both fail on master and pass with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
