### PR TITLE
Handle devices that don't report motion detection state

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -214,19 +214,24 @@ class HikCamera(object):
 
         try:
             tree = ET.fromstring(response.text)
-            self.fetch_namespace(tree, CONTEXT_MOTION)
-            enabled = tree.find(self.element_query('enabled', CONTEXT_MOTION))
-
-            if enabled is not None:
-                self._motion_detection_xml = tree
-            self.motion_detection = {'true': True, 'false': False}[enabled.text]
-            return self.motion_detection
-
-        except AttributeError as err:
-            _LOGGING.error('Entire response: %s', response.text)
-            _LOGGING.error('There was a problem: %s', err)
+        except ET.ParseError as err:
+            _LOGGING.debug('Malformed motion detection response: %s', err)
             self.motion_detection = None
             return self.motion_detection
+
+        self.fetch_namespace(tree, CONTEXT_MOTION)
+        enabled = tree.find(self.element_query('enabled', CONTEXT_MOTION))
+
+        if enabled is None:
+            # NVRs and some cameras answer 200 with a different document.
+            # They don't support the endpoint; that isn't an error.
+            _LOGGING.debug('Device does not report motion detection state.')
+            self.motion_detection = None
+            return self.motion_detection
+
+        self._motion_detection_xml = tree
+        self.motion_detection = {'true': True, 'false': False}.get(enabled.text)
+        return self.motion_detection
 
     def enable_motion_detection(self):
         """Enable motion detection"""

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -696,5 +696,39 @@ class StreamReliabilityTestCase(unittest.TestCase):
         self.assertIn("timeout", alternate_call.kwargs)
 
 
+class MotionDetectionUnsupportedTestCase(unittest.TestCase):
+    """NVRs answer the motionDetection endpoint with 200 and a document that
+    has no 'enabled' element. That is unsupported, not an error."""
+
+    @staticmethod
+    def _camera_answering(text):
+        with patch("pyhik.hikvision.requests.Session") as mock_session, \
+                patch("pyhik.hikvision.HikCamera.get_device_info") as mock_info, \
+                patch("pyhik.hikvision.HikCamera.get_event_triggers") as mock_triggers:
+            mock_info.return_value = {
+                "deviceName": "Test", "deviceID": "12345678901"}
+            mock_triggers.return_value = {"VMD": [1]}
+            response = MagicMock()
+            response.status_code = requests.codes.ok
+            response.ok = True
+            response.text = text
+            mock_session.return_value.get.return_value = response
+            return HikCamera(host="localhost")
+
+    def test_document_without_enabled_element(self):
+        with self.assertNoLogs("pyhik.hikvision", level=logging.ERROR):
+            camera = self._camera_answering(
+                '<SomeOtherDocument '
+                'xmlns="http://www.hikvision.com/ver20/XMLSchema"/>')
+
+        self.assertIsNone(camera.current_motion_detection_state)
+
+    def test_response_that_is_not_xml(self):
+        with self.assertNoLogs("pyhik.hikvision", level=logging.ERROR):
+            camera = self._camera_answering("not xml at all")
+
+        self.assertIsNone(camera.current_motion_detection_state)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Split out of #121.

NVRs answer `/ISAPI/System/Video/inputs/channels/1/motionDetection` with 200 and a document that has no `enabled` element. `get_motion_detection()` then dereferenced `None` and logged the entire response body plus `There was a problem: 'NoneType' object has no attribute 'text'` at error level, on every poll. A device not supporting the endpoint isn't an error, so that's a debug message now.

Separately, a response that isn't XML at all raised `ET.ParseError` straight out of the method — the `except AttributeError` never covered it. It now returns `None` like the other unsupported cases.

Reported in home-assistant/core#165422.

Two tests added; both fail on master and pass with the change. This is self-contained in `get_motion_detection()` and doesn't overlap the other splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
