### PR TITLE
Fix the two failing tests on master

### DIFF
--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -443,7 +443,7 @@ class ThreadSafetyTestCase(unittest.TestCase):
         result = camera.get_snapshot()
 
         # API session should have been called for the snapshot
-        snapshot_url = "localhost:80/ISAPI/Streaming/channels/1/picture"
+        snapshot_url = "http://localhost:80/ISAPI/Streaming/channels/1/picture"
         api_session.get.assert_called_with(snapshot_url, timeout=10)
 
         # Stream session should NOT have been called for the snapshot
@@ -455,7 +455,7 @@ class ThreadSafetyTestCase(unittest.TestCase):
         """Create an NVR without running unrelated initialization requests."""
         camera = object.__new__(HikCamera)
         camera.device_type = NVR_DEVICE
-        camera.root_url = "localhost:80"
+        camera.root_url = "http://localhost:80"
         camera.name = "Test"
         camera.hik_request = MagicMock(name="api_session")
         return camera
@@ -473,11 +473,11 @@ class ThreadSafetyTestCase(unittest.TestCase):
             camera.hik_request.get.call_args_list,
             [
                 call(
-                    "localhost:80/ISAPI/Streaming/channels/201/picture",
+                    "http://localhost:80/ISAPI/Streaming/channels/201/picture",
                     timeout=10,
                 ),
                 call(
-                    "localhost:80/ISAPI/ContentMgmt/StreamingProxy/channels/201/picture",
+                    "http://localhost:80/ISAPI/ContentMgmt/StreamingProxy/channels/201/picture",
                     timeout=10,
                 ),
             ],
@@ -492,7 +492,7 @@ class ThreadSafetyTestCase(unittest.TestCase):
 
         self.assertEqual(camera.get_snapshot(), b"legacy_image")
         camera.hik_request.get.assert_called_once_with(
-            "localhost:80/ISAPI/Streaming/channels/101/picture", timeout=10
+            "http://localhost:80/ISAPI/Streaming/channels/101/picture", timeout=10
         )
 
     def test_nvr_snapshot_does_not_fall_back_after_auth_failure(self):
@@ -504,7 +504,7 @@ class ThreadSafetyTestCase(unittest.TestCase):
 
         self.assertIsNone(camera.get_snapshot())
         camera.hik_request.get.assert_called_once_with(
-            "localhost:80/ISAPI/Streaming/channels/101/picture", timeout=10
+            "http://localhost:80/ISAPI/Streaming/channels/101/picture", timeout=10
         )
 
     @patch("pyhik.hikvision.HikCamera.get_device_info")

--- a/test/test_isapi.py
+++ b/test/test_isapi.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock, patch, PropertyMock
 
 import requests
 
+# xmltodict is an optional extra (pip install pyHik[isapi]); tests that need
+# response parsing are skipped when it isn't installed.
+from pyhik.isapi import xmltodict
 from pyhik.isapi import (
     ISAPIClient,
     ISAPIError,
@@ -175,6 +178,7 @@ class TestISAPIClientBasics(unittest.TestCase):
 class TestISAPIClientRequests(unittest.TestCase):
     """Test ISAPIClient HTTP request handling."""
 
+    @unittest.skipIf(xmltodict is None, "requires the isapi extra")
     def test_auth_detection_digest(self, mock_session_class):
         """Test digest auth detection."""
         session = mock_session_class.return_value


### PR DESCRIPTION
Master is red at 02c3d07 — this makes `python -m unittest discover -s test -t .` pass. Independent of #122–#127, no library code changes.

**`test_snapshot_uses_api_session`** — #120 changed `root_url` to carry the scheme (`http://localhost:80`) and updated two of the three places the tests hard-code it, so the snapshot assertion still expected the old bare `localhost:80`. The library is right; the test was stale. I also fixed the `nvr_camera()` fixture, which hand-sets `root_url = "localhost:80"` — its own assertions agreed with it so nothing failed, but a fixture that can't occur in practice is what let this slip in the first place.

**`test_auth_detection_digest`** — `get_device_info()` parses the response, so the test needs `xmltodict`, which is an optional extra (`extras_require={'isapi': ...}`). On a plain `pip install -e .` it errors out. Skipped unless the extra is installed, so a bare checkout is green and installing `.[isapi]` still runs it for real.

Verified both ways: 44 passed with xmltodict, 43 passed + 1 skipped without.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
