### PR TITLE
Wake the stream thread's retry backoff on disconnect()

### DIFF
--- a/pyhik/hikvision.py
+++ b/pyhik/hikvision.py
@@ -11,7 +11,6 @@ http://oversea-download.hikvision.com/uploadfile/Leaflet/ISAPI/HIKVISION%20ISAPI
 Imaging:
 http://oversea-download.hikvision.com/uploadfile/Leaflet/ISAPI/HIKVISION%20ISAPI_2.0-Image%20Service.pdf
 """
-import time
 import datetime
 from dataclasses import dataclass
 import logging
@@ -741,7 +740,7 @@ class HikCamera(object):
         url = '%s/ISAPI/Event/notification/alertStream' % self.root_url
 
         # pylint: disable=too-many-nested-blocks
-        while True:
+        while not kill_event.is_set():
 
             try:
                 stream = self.hik_request_stream.get(url, stream=True,
@@ -797,12 +796,7 @@ class HikCamera(object):
 
                 if kill_event.is_set():
                     # We were asked to stop the thread so lets do so.
-                    _LOGGING.debug('Stopping event stream thread for %s',
-                                   self.name)
-                    self._set_stream_connected(False)
-                    self.watchdog.stop()
-                    self.hik_request_stream.close()
-                    return
+                    break
                 elif reset_event.is_set():
                     # We need to reset the connection.
                     raise ValueError('Watchdog failed.')
@@ -826,10 +820,21 @@ class HikCamera(object):
                 parse_string = ""
                 self.watchdog.stop()
                 self.hik_request_stream.close()
-                time.sleep(5)
+                # disconnect() sets the kill event and then joins this thread
+                # with no timeout, so every wait in here is a wait its caller
+                # cannot escape. Sleeping the backoff out would hold up a host
+                # shutdown for as long as the backoff lasts, and the backoff
+                # grows with every failure.
+                if kill_event.wait(5):
+                    break
                 self.update_stale()
-                time.sleep(fail_count * 5)
-                continue
+                if kill_event.wait(fail_count * 5):
+                    break
+
+        _LOGGING.debug('Stopping event stream thread for %s', self.name)
+        self._set_stream_connected(False)
+        self.watchdog.stop()
+        self.hik_request_stream.close()
 
     def process_stream(self, tree):
         """Process incoming event stream packets."""

--- a/test/test_hikvision.py
+++ b/test/test_hikvision.py
@@ -5,6 +5,7 @@ import io
 import logging
 import requests
 import threading
+import time
 import unittest
 import xml.etree.ElementTree as ET
 
@@ -670,40 +671,75 @@ class DuplicateChannelsTestCase(unittest.TestCase):
         self.assertEqual(len(camera.event_states["Motion"]), 1)
 
 
-class StopLoop(Exception):
-    """Raised from a patched sleep to leave alert_stream's endless loop."""
+def killed_after(retries):
+    """A kill event that answers 'not yet' to the backoff waits of the first
+    `retries` attempts and stops the loop on the next one, so a test can run a
+    fixed number of reconnects without waiting out the real backoff."""
+    kill_event = MagicMock()
+    kill_event.is_set.return_value = False
+    kill_event.wait.side_effect = [False] * (2 * retries) + [True]
+    return kill_event
 
 
 class StreamReliabilityTestCase(unittest.TestCase):
-    @patch("pyhik.hikvision.time.sleep")
-    def test_read_timeout_does_not_kill_the_thread(self, mock_sleep):
+    def test_read_timeout_does_not_kill_the_thread(self):
         """A read timeout is how a silently dropped connection surfaces. If it
         escapes the loop the thread dies and events stop for good."""
         camera = make_camera()
         camera.hik_request_stream = MagicMock()
         camera.hik_request_stream.get.side_effect = \
             requests.exceptions.ReadTimeout("read timed out")
-        # Leave the retry loop rather than sleeping through the backoff.
-        mock_sleep.side_effect = [None, StopLoop]
 
-        with self.assertRaises(StopLoop):
-            camera.alert_stream(threading.Event(), threading.Event())
+        camera.alert_stream(threading.Event(), killed_after(1))
 
-    @patch("pyhik.hikvision.time.sleep")
-    def test_alternate_stream_url_has_a_timeout(self, mock_sleep):
+        self.assertEqual(camera.hik_request_stream.get.call_count, 2)
+
+    def test_alternate_stream_url_has_a_timeout(self):
         """Without a timeout the fallback request can block the thread
         forever on a device that accepts the connection and never answers."""
         camera = make_camera()
         camera.hik_request_stream = MagicMock()
         camera.hik_request_stream.get.return_value = MagicMock(
             status_code=requests.codes.not_found)
-        mock_sleep.side_effect = [None, StopLoop]
 
-        with self.assertRaises(StopLoop):
-            camera.alert_stream(threading.Event(), threading.Event())
+        camera.alert_stream(threading.Event(), killed_after(0))
 
         alternate_call = camera.hik_request_stream.get.call_args_list[1]
         self.assertIn("timeout", alternate_call.kwargs)
+
+    def test_disconnect_does_not_wait_out_the_backoff(self):
+        """disconnect() joins this thread with no timeout, so a backoff that
+        ignores the kill event is a wait its caller cannot escape. A host
+        shutting down while the camera is unreachable would block on it."""
+        camera = make_camera()
+        camera.hik_request_stream = MagicMock()
+        failing = threading.Event()
+
+        def unreachable(*args, **kwargs):
+            failing.set()
+            raise requests.exceptions.ConnectionError("no route to host")
+
+        camera.hik_request_stream.get.side_effect = unreachable
+
+        camera.start_stream()
+        self.assertTrue(failing.wait(5))
+        started = time.monotonic()
+        camera.disconnect()
+
+        # The backoff it was sitting in is 5s, and grows with every failure.
+        self.assertLess(time.monotonic() - started, 4)
+
+    def test_a_killed_stream_does_not_reconnect(self):
+        """The kill event can arrive while the thread is between attempts.
+        Reconnecting then leaves a thread nobody is going to join again."""
+        camera = make_camera()
+        camera.hik_request_stream = MagicMock()
+        kill_event = threading.Event()
+        kill_event.set()
+
+        camera.alert_stream(threading.Event(), kill_event)
+
+        camera.hik_request_stream.get.assert_not_called()
 
 
 class StreamConnectedTestCase(unittest.TestCase):


### PR DESCRIPTION
`disconnect()` sets the kill event and then joins the stream thread with no timeout. The reconnect path in `alert_stream()` slept through its backoff without ever looking at that event, and then reconnected without looking either — the event is only checked while a *successful* stream is being read. So with the camera unreachable the thread failed, slept, retried, failed again, and `disconnect()` never returned at all.

The thread is non-daemonic, so this is worse than a slow shutdown for a consumer. Home Assistant awaits `disconnect()` on its stop event; the stop stage times out and the process is left with a live thread publishing into an event loop that has stopped. Found by a review on home-assistant/core#180873.

## Changes

- both backoff sleeps become `kill_event.wait(...)`, returning as soon as the thread is asked to stop
- the loop checks the kill event before opening another connection
- the stop path is now a single exit at the bottom of the loop rather than an early `return` in the middle
- `import time` is no longer needed

## Tests

`test_disconnect_does_not_wait_out_the_backoff` runs a real thread against an unreachable camera, calls `disconnect()` while it is in the backoff, and asserts it returns promptly. Without this change that test does not fail, it hangs — which is the bug.

`test_a_killed_stream_does_not_reconnect` covers the other half: a kill event set between attempts must not open another connection.

The two existing stream tests drove the loop off a patched `time.sleep`; they now drive it off the kill event instead. 65 passed.